### PR TITLE
Disable dump() methods on Windows

### DIFF
--- a/bits/function.h
+++ b/bits/function.h
@@ -653,7 +653,9 @@ PHP_METHOD(Func, dump) {
 	zval *zname = NULL, *zoutput = NULL;
 	php_jit_function_t *pfunc;
 	php_stream *pstream = NULL;
-	
+
+	JIT_WIN32_NOT_IMPLEMENTED();
+
 	if (php_jit_parameters("z|r", &zname, &zoutput) != SUCCESS || 
 		(!zname || Z_TYPE_P(zname) != IS_STRING)) {
 		php_jit_exception("unexpected parameters, expected (string name [, resource output = STDOUT])");

--- a/bits/type.h
+++ b/bits/type.h
@@ -288,7 +288,9 @@ PHP_METHOD(Type, dump) {
 	zval *zoutput = NULL;
 	php_jit_type_t *ptype;
 	php_stream *pstream = NULL;
-	
+
+	JIT_WIN32_NOT_IMPLEMENTED();
+
 	if (php_jit_parameters("|r", &zoutput) != SUCCESS) {
 		php_jit_exception("unexpected parameters, expected ([resource output = STDOUT])");
 		return;

--- a/bits/value.h
+++ b/bits/value.h
@@ -317,7 +317,9 @@ PHP_METHOD(Value, dump) {
 	zval *zoutput = NULL, *zprefix = NULL;
 	php_jit_value_t *pval;
 	php_stream *pstream = NULL;
-	
+
+	JIT_WIN32_NOT_IMPLEMENTED();
+
 	if (php_jit_parameters("|rz", &zoutput, &zprefix) != SUCCESS) {
 		php_jit_exception("unexpected parameters, expected ([resource output = STDOUT, string prefix = NULL])");
 		return;

--- a/php_jitfu.h
+++ b/php_jitfu.h
@@ -64,6 +64,12 @@ extern zend_class_entry *jit_exception_ce;
 #define php_jit_exception(s, ...)     zend_throw_exception_ex(jit_exception_ce, 0 TSRMLS_CC, s, ##__VA_ARGS__)
 #define php_jit_parameters(s, ...)    zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, s, ##__VA_ARGS__)
 
+#ifdef PHP_WIN32
+# define JIT_WIN32_NOT_IMPLEMENTED() php_jit_exception("functionality not yet implemented on the Windows platform"); return
+#else
+# define JIT_WIN32_NOT_IMPLEMENTED()
+#endif
+
 #endif	/* PHP_JITFU_H */
 
 /*


### PR DESCRIPTION
The `->dump()` methods cannot currently work on Windows. The libjit functions they wrap accept a `FILE *` as the output mechanism, and due to the fact that the libjit.dll on which Windows builds are based is built with mingw, these cannot currently be called sanely.

In order to pass file pointers across DLL boundaries, the same C runtime must be used. See http://msdn.microsoft.com/en-us/library/ms235460.aspx for more information. If a sane libjit.dll can be built with MSVC at some stage, these functions can potentially be enabled on Windows.

I have elected to throw an exception rather than disabling the functions completely, as this allows for cleaner userland handling (IMO).
